### PR TITLE
Fix LoadError when enabling Prosopite

### DIFF
--- a/lib/cookpad/performance/engine.rb
+++ b/lib/cookpad/performance/engine.rb
@@ -7,6 +7,7 @@ module Cookpad
         if !Rails.env.production? &&
            (ENV["LOG_N_PLUS_ONE_QUERIES"] == "true" ||
              ENV["RAISE_N_PLUS_ONE_QUERIES"] == "true")
+          require "app/controllers/concerns/n_plus_one_detection"
           ActionController::Base.include(NPlusOneDetection)
         end
       end

--- a/lib/cookpad/performance/engine.rb
+++ b/lib/cookpad/performance/engine.rb
@@ -7,7 +7,8 @@ module Cookpad
         if !Rails.env.production? &&
            (ENV["LOG_N_PLUS_ONE_QUERIES"] == "true" ||
              ENV["RAISE_N_PLUS_ONE_QUERIES"] == "true")
-          require "app/controllers/concerns/n_plus_one_detection"
+
+          require Cookpad::Performance::Engine.root.join("app/controllers/concerns/n_plus_one_detection")
           ActionController::Base.include(NPlusOneDetection)
         end
       end


### PR DESCRIPTION
Explicitly require n-plus-one concern in the Engine to ensure module is available to include in `to_prepare`