### PR TITLE
Disable webpacker compilation in profile mode

### DIFF
--- a/config/initializers/n_plus_one_detection.rb
+++ b/config/initializers/n_plus_one_detection.rb
@@ -1,5 +1,5 @@
 if (ENV["LOG_N_PLUS_ONE_QUERIES"] == "true" || ENV["RAISE_N_PLUS_ONE_QUERIES"] == "true") &&
-  (Rails.env.development? || Rails.env.test?)
+   (Rails.env.development? || Rails.env.test?)
   require "prosopite"
   Prosopite.rails_logger = ENV["LOG_N_PLUS_ONE_QUERIES"] == "true"
   Prosopite.prosopite_logger = true

--- a/lib/cookpad/performance.rb
+++ b/lib/cookpad/performance.rb
@@ -1,6 +1,7 @@
 require "rails"
 require "cookpad/performance/version"
 require "cookpad/performance/engine"
+require "cookpad/performance/railtie" if defined?(Rails::Railtie)
 
 module Cookpad
   module Performance

--- a/lib/cookpad/performance/railtie.rb
+++ b/lib/cookpad/performance/railtie.rb
@@ -1,6 +1,15 @@
 module Cookpad
   module Performance
     class Railtie < ::Rails::Railtie
+      DEFAULTS_IVAR_NAME = "@defaults"
+
+      config.after_initialize  do
+        if ENV["PROFILE"] && Rails.env.development? && defined?(Webpacker)
+          default_config = Webpacker.config.instance_variable_get(DEFAULTS_IVAR_NAME)
+          default_config["compile"] = false
+          Webpacker.config.instance_variable_set(DEFAULTS_IVAR_NAME, default_config)
+        end
+      end
     end
   end
 end

--- a/lib/cookpad/performance/railtie.rb
+++ b/lib/cookpad/performance/railtie.rb
@@ -1,9 +1,10 @@
 module Cookpad
   module Performance
     class Railtie < ::Rails::Railtie
-      DEFAULTS_IVAR_NAME = "@defaults"
+      DEFAULTS_IVAR_NAME = "@defaults".freeze
+      private_constant :DEFAULTS_IVAR_NAME
 
-      config.after_initialize  do
+      config.after_initialize do
         if ENV["PROFILE"] && Rails.env.development? && defined?(Webpacker)
           default_config = Webpacker.config.instance_variable_get(DEFAULTS_IVAR_NAME)
           default_config["compile"] = false

--- a/lib/cookpad/performance/railtie.rb
+++ b/lib/cookpad/performance/railtie.rb
@@ -1,0 +1,6 @@
+module Cookpad
+  module Performance
+    class Railtie < ::Rails::Railtie
+    end
+  end
+end

--- a/spec/support/initialization_helpers.rb
+++ b/spec/support/initialization_helpers.rb
@@ -1,5 +1,4 @@
 module InitializationHelpers
-
   private
 
     def unload_prosopite


### PR DESCRIPTION
## What

Adds a Railtie file with a hook to disable webpacker

## Why

This was causing dev to run very slowly in PROFILE mode, since Webpacker was still trying to compile assets on change

## How

Changes the webpacker default configurations hash

Fixes cookpad/global-web-platform#576